### PR TITLE
Updated Documentation to contain Decision Tree Splitting Methods

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,7 @@ extensions = [
 # Specify how to identify the prompt when copying code snippets
 copybutton_prompt_text = r">>> |\.\.\. "
 copybutton_prompt_is_regexp = True
+copybutton_exclude = "style"
 
 try:
     import jupyterlite_sphinx  # noqa: F401

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -229,10 +229,13 @@ console:
 For 64-bit Python, configure the build environment by running the following
 commands in ``cmd`` or an Anaconda Prompt (if you use Anaconda):
 
-    ::
+.. sphinx-prompt 1.3.0 (used in doc-min-dependencies CI task) does not support `batch` prompt type,
+.. so we work around by using a known prompt type and an explicit prompt text.
+..
+.. prompt:: bash C:\>
 
-      $ SET DISTUTILS_USE_SDK=1
-      $ "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+    SET DISTUTILS_USE_SDK=1
+    "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 Replace ``x64`` by ``x86`` to build for 32-bit Python.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -71,32 +71,32 @@ Then run:
 
   <div class="highlight">
     <pre class="sk-expandable" data-packager="pip" data-os="linux" data-venv="no"
-    ><span class="prompt1">pip3 install -U scikit-learn</span></pre>
-    
+    ><span>pip3 install -U scikit-learn</span></pre>
+
     <pre class="sk-expandable" data-packager="pip" data-os="windows" data-venv="no"
-    ><span class="prompt1">pip install -U scikit-learn</span></pre>
-    
+    ><span>pip install -U scikit-learn</span></pre>
+
     <pre class="sk-expandable" data-packager="pip" data-os="mac" data-venv="no"
-    ><span class="prompt1">pip install -U scikit-learn</span></pre>
-    
+    ><span>pip install -U scikit-learn</span></pre>
+
     <pre class="sk-expandable" data-packager="pip" data-os="linux" data-venv=""
-    ><span class="prompt1">python3 -m venv sklearn-venv</span>
-  <span class="prompt1">source sklearn-venv/bin/activate</span>
-  <span class="prompt1">pip3 install -U scikit-learn</span></pre>
-    
+    ><span>python3 -m venv sklearn-venv</span>
+  <span>source sklearn-venv/bin/activate</span>
+  <span>pip3 install -U scikit-learn</span></pre>
+
     <pre class="sk-expandable" data-packager="pip" data-os="windows" data-venv=""
-    ><span class="prompt1">python -m venv sklearn-venv</span>
-  <span class="prompt1">sklearn-venv\Scripts\activate</span>
-  <span class="prompt1">pip install -U scikit-learn</span></pre>
-    
+    ><span>python -m venv sklearn-venv</span>
+  <span>sklearn-venv\Scripts\activate</span>
+  <span>pip install -U scikit-learn</span></pre>
+
     <pre class="sk-expandable" data-packager="pip" data-os="mac" data-venv=""
-    ><span class="prompt1">python -m venv sklearn-venv</span>
-  <span class="prompt1">source sklearn-venv/bin/activate</span>
-  <span class="prompt1">pip install -U scikit-learn</span></pre>
+    ><span>python -m venv sklearn-venv</span>
+  <span>source sklearn-venv/bin/activate</span>
+  <span>pip install -U scikit-learn</span></pre>
 
     <pre class="sk-expandable" data-packager="conda"
-    ><span class="prompt1">conda create -n sklearn-env -c conda-forge scikit-learn</span>
-  <span class="prompt1">conda activate sklearn-env</span></pre>
+    ><span>conda create -n sklearn-env -c conda-forge scikit-learn</span>
+  <span>conda activate sklearn-env</span></pre>
   </div>
 
 In order to check your installation you can use
@@ -105,29 +105,29 @@ In order to check your installation you can use
 
   <div class="highlight">
     <pre class="sk-expandable" data-packager="pip" data-os="linux" data-venv="no"
-    ><span class="prompt1">python3 -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
-  <span class="prompt1">python3 -m pip freeze  # to see all packages installed in the active virtualenv</span>
-  <span class="prompt1">python3 -c "import sklearn; sklearn.show_versions()"</span></pre>
+    ><span>python3 -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
+  <span>python3 -m pip freeze  # to see all packages installed in the active virtualenv</span>
+  <span>python3 -c "import sklearn; sklearn.show_versions()"</span></pre>
 
     <pre class="sk-expandable" data-packager="pip" data-os="windows" data-venv="no"
-    ><span class="prompt1">python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
-  <span class="prompt1">python -m pip freeze  # to see all packages installed in the active virtualenv</span>
-  <span class="prompt1">python -c "import sklearn; sklearn.show_versions()"</span></pre>
+    ><span>python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
+  <span>python -m pip freeze  # to see all packages installed in the active virtualenv</span>
+  <span>python -c "import sklearn; sklearn.show_versions()"</span></pre>
 
     <pre class="sk-expandable" data-packager="pip" data-os="mac" data-venv="no"
-    ><span class="prompt1">python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
-  <span class="prompt1">python -m pip freeze  # to see all packages installed in the active virtualenv</span>
-  <span class="prompt1">python -c "import sklearn; sklearn.show_versions()"</span></pre>
+    ><span>python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
+  <span>python -m pip freeze  # to see all packages installed in the active virtualenv</span>
+  <span>python -c "import sklearn; sklearn.show_versions()"</span></pre>
 
     <pre class="sk-expandable" data-packager="pip" data-venv=""
-    ><span class="prompt1">python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
-  <span class="prompt1">python -m pip freeze  # to see all packages installed in the active virtualenv</span>
-  <span class="prompt1">python -c "import sklearn; sklearn.show_versions()"</span></pre>
+    ><span>python -m pip show scikit-learn  # to see which version and where scikit-learn is installed</span>
+  <span>python -m pip freeze  # to see all packages installed in the active virtualenv</span>
+  <span>python -c "import sklearn; sklearn.show_versions()"</span></pre>
 
     <pre class="sk-expandable" data-packager="conda"
-    ><span class="prompt1">conda list scikit-learn  # to see which scikit-learn version is installed</span>
-  <span class="prompt1">conda list  # to see all packages installed in the active conda environment</span>
-  <span class="prompt1">python -c "import sklearn; sklearn.show_versions()"</span></pre>
+    ><span>conda list scikit-learn  # to see which scikit-learn version is installed</span>
+  <span>conda list  # to see all packages installed in the active conda environment</span>
+  <span>python -c "import sklearn; sklearn.show_versions()"</span></pre>
   </div>
 
 Note that in order to avoid potential conflicts with other packages it is
@@ -290,7 +290,7 @@ Note that those solvers are not enabled by default, please refer to the
 `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/what-is-patching.html>`_
 documentation for more details on usage scenarios. Direct export example:
 
-.. prompt:: bash $
+.. prompt:: python >>>
 
   from sklearnex.neighbors import NearestNeighbors
 
@@ -340,6 +340,6 @@ using the ``regedit`` tool:
 
 #. Reinstall scikit-learn (ignoring the previous broken installation):
 
-.. prompt:: python $
+.. prompt:: bash $
 
     pip install --exists-action=i scikit-learn

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -125,8 +125,8 @@ automatically skipped. Therefore it's important to run the tests with the
 
 .. prompt:: bash $
 
-    $ pip install array-api-compat  # and other libraries as needed
-    $ pytest -k "array_api" -v
+    pip install array-api-compat  # and other libraries as needed
+    pytest -k "array_api" -v
 
 Note on MPS device support
 --------------------------
@@ -143,7 +143,7 @@ To enable the MPS support in PyTorch, set the environment variable
 
 .. prompt:: bash $
 
-    $ PYTORCH_ENABLE_MPS_FALLBACK=1 pytest -k "array_api" -v
+    PYTORCH_ENABLE_MPS_FALLBACK=1 pytest -k "array_api" -v
 
 At the time of writing all scikit-learn tests should pass, however, the
 computational speed is not necessarily better than with the CPU device.

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -201,31 +201,36 @@ alpha parameter, the fewer features selected.
 
 .. _compressive_sensing:
 
-.. topic:: **L1-recovery and compressive sensing**
+|details-start|
+**L1-recovery and compressive sensing**
+|details-split|
 
-   For a good choice of alpha, the :ref:`lasso` can fully recover the
-   exact set of non-zero variables using only few observations, provided
-   certain specific conditions are met. In particular, the number of
-   samples should be "sufficiently large", or L1 models will perform at
-   random, where "sufficiently large" depends on the number of non-zero
-   coefficients, the logarithm of the number of features, the amount of
-   noise, the smallest absolute value of non-zero coefficients, and the
-   structure of the design matrix X. In addition, the design matrix must
-   display certain specific properties, such as not being too correlated.
+For a good choice of alpha, the :ref:`lasso` can fully recover the
+exact set of non-zero variables using only few observations, provided
+certain specific conditions are met. In particular, the number of
+samples should be "sufficiently large", or L1 models will perform at
+random, where "sufficiently large" depends on the number of non-zero
+coefficients, the logarithm of the number of features, the amount of
+noise, the smallest absolute value of non-zero coefficients, and the
+structure of the design matrix X. In addition, the design matrix must
+display certain specific properties, such as not being too correlated.
 
-   There is no general rule to select an alpha parameter for recovery of
-   non-zero coefficients. It can by set by cross-validation
-   (:class:`~sklearn.linear_model.LassoCV` or
-   :class:`~sklearn.linear_model.LassoLarsCV`), though this may lead to
-   under-penalized models: including a small number of non-relevant variables
-   is not detrimental to prediction score. BIC
-   (:class:`~sklearn.linear_model.LassoLarsIC`) tends, on the opposite, to set
-   high values of alpha.
+There is no general rule to select an alpha parameter for recovery of
+non-zero coefficients. It can by set by cross-validation
+(:class:`~sklearn.linear_model.LassoCV` or
+:class:`~sklearn.linear_model.LassoLarsCV`), though this may lead to
+under-penalized models: including a small number of non-relevant variables
+is not detrimental to prediction score. BIC
+(:class:`~sklearn.linear_model.LassoLarsIC`) tends, on the opposite, to set
+high values of alpha.
 
-   **Reference** Richard G. Baraniuk "Compressive Sensing", IEEE Signal
+.. topic:: Reference
+
+   Richard G. Baraniuk "Compressive Sensing", IEEE Signal
    Processing Magazine [120] July 2007
    http://users.isr.ist.utl.pt/~aguiar/CS_notes.pdf
 
+|details-end|
 
 Tree-based feature selection
 ----------------------------
@@ -282,6 +287,10 @@ instead of starting with no features and greedily adding features, we start
 with *all* the features and greedily *remove* features from the set. The
 `direction` parameter controls whether forward or backward SFS is used.
 
+|details-start|
+**Detail on Sequential Feature Selection**
+|details-split|
+
 In general, forward and backward selection do not yield equivalent results.
 Also, one may be much faster than the other depending on the requested number
 of selected features: if we have 10 features and ask for 7 selected features,
@@ -299,15 +308,17 @@ cross-validation requires fitting `m * k` models, while
 :class:`~sklearn.feature_selection.SelectFromModel` always just does a single
 fit and requires no iterations.
 
-.. topic:: Examples
-
-    * :ref:`sphx_glr_auto_examples_feature_selection_plot_select_from_model_diabetes.py`
-
-.. topic:: References:
+.. topic:: Reference
 
    .. [sfs] Ferri et al, `Comparative study of techniques for
       large-scale feature selection
       <https://citeseerx.ist.psu.edu/doc_view/pid/5fedabbb3957bbb442802e012d829ee0629a01b6>`_.
+
+|details-end|
+
+.. topic:: Examples
+
+    * :ref:`sphx_glr_auto_examples_feature_selection_plot_select_from_model_diabetes.py`
 
 Feature selection as part of a pipeline
 =======================================

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -130,8 +130,10 @@ distances between all points.  Isomap can be performed with the object
    :align: center
    :scale: 50
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
+
 The Isomap algorithm comprises three stages:
 
 1. **Nearest neighbor search.**  Isomap uses
@@ -162,6 +164,8 @@ The overall complexity of Isomap is
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
 
+|details-end|
+
 .. topic:: References:
 
    * `"A global geometric framework for nonlinear dimensionality reduction"
@@ -187,8 +191,9 @@ Locally linear embedding can be performed with function
    :align: center
    :scale: 50
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
 
 The standard LLE algorithm comprises three stages:
 
@@ -208,6 +213,8 @@ The overall complexity of standard LLE is
 * :math:`D` : input dimension
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
+
+|details-end|
 
 .. topic:: References:
 
@@ -241,8 +248,9 @@ It requires ``n_neighbors > n_components``.
    :align: center
    :scale: 50
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
 
 The MLLE algorithm comprises three stages:
 
@@ -264,6 +272,8 @@ The overall complexity of MLLE is
 * :math:`D` : input dimension
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
+
+|details-end|
 
 .. topic:: References:
 
@@ -291,8 +301,9 @@ It requires ``n_neighbors > n_components * (n_components + 3) / 2``.
    :align: center
    :scale: 50
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
 
 The HLLE algorithm comprises three stages:
 
@@ -312,6 +323,8 @@ The overall complexity of standard HLLE is
 * :math:`D` : input dimension
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
+
+|details-end|
 
 .. topic:: References:
 
@@ -335,8 +348,9 @@ preserving local distances. Spectral embedding can be  performed with the
 function :func:`spectral_embedding` or its object-oriented counterpart
 :class:`SpectralEmbedding`.
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
 
 The Spectral Embedding (Laplacian Eigenmaps) algorithm comprises three stages:
 
@@ -357,6 +371,8 @@ The overall complexity of spectral embedding is
 * :math:`D` : input dimension
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
+
+|details-end|
 
 .. topic:: References:
 
@@ -383,8 +399,9 @@ tangent spaces to learn the embedding.  LTSA can be performed with function
    :align: center
    :scale: 50
 
-Complexity
-----------
+|details-start|
+**Complexity**
+|details-split|
 
 The LTSA algorithm comprises three stages:
 
@@ -403,6 +420,8 @@ The overall complexity of standard LTSA is
 * :math:`D` : input dimension
 * :math:`k` : number of nearest neighbors
 * :math:`d` : output dimension
+
+|details-end|
 
 .. topic:: References:
 
@@ -448,8 +467,9 @@ the similarities chosen in some optimal ways. The objective, called the
 stress, is then defined by :math:`\sum_{i < j} d_{ij}(X) - \hat{d}_{ij}(X)`
 
 
-Metric MDS
-----------
+|details-start|
+**Metric MDS**
+|details-split|
 
 The simplest metric :class:`MDS` model, called *absolute MDS*, disparities are defined by
 :math:`\hat{d}_{ij} = S_{ij}`. With absolute MDS, the value :math:`S_{ij}`
@@ -458,8 +478,11 @@ should then correspond exactly to the distance between point :math:`i` and
 
 Most commonly, disparities are set to :math:`\hat{d}_{ij} = b S_{ij}`.
 
-Nonmetric MDS
--------------
+|details-end|
+
+|details-start|
+**Nonmetric MDS**
+|details-split|
 
 Non metric :class:`MDS` focuses on the ordination of the data. If
 :math:`S_{ij} > S_{jk}`, then the embedding should enforce :math:`d_{ij} <
@@ -490,6 +513,7 @@ in the metric case.
    :align: center
    :scale: 60
 
+|details-end|
 
 .. topic:: References:
 
@@ -551,8 +575,10 @@ The disadvantages to using t-SNE are roughly:
    :align: center
    :scale: 50
 
-Optimizing t-SNE
-----------------
+|details-start|
+**Optimizing t-SNE**
+|details-split|
+
 The main purpose of t-SNE is visualization of high-dimensional data. Hence,
 it works best when the data will be embedded on two or three dimensions.
 
@@ -601,8 +627,11 @@ but less accurate results.
 provides a good discussion of the effects of the various parameters, as well
 as interactive plots to explore the effects of different parameters.
 
-Barnes-Hut t-SNE
-----------------
+|details-end|
+
+|details-start|
+**Barnes-Hut t-SNE**
+|details-split|
 
 The Barnes-Hut t-SNE that has been implemented here is usually much slower than
 other manifold learning algorithms. The optimization is quite difficult
@@ -638,6 +667,7 @@ imply that the data cannot be correctly classified by a supervised model. It
 might be the case that 2 dimensions are not high enough to accurately represent
 the internal structure of the data.
 
+|details-end|
 
 .. topic:: References:
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -146,6 +146,10 @@ Once trained, you can plot the tree with the :func:`plot_tree` function::
    :scale: 75
    :align: center
 
+|details-start|
+**Alternative ways to export trees**
+|details-split|
+
 We can also export the tree in `Graphviz
 <https://www.graphviz.org/>`_ format using the :func:`export_graphviz`
 exporter. If you use the `conda <https://conda.io>`_ package manager, the graphviz binaries
@@ -211,6 +215,8 @@ of external libraries and is more compact:
     |   |--- petal width (cm) >  1.75
     |   |   |--- class: 2
     <BLANKLINE>
+
+|details-end|
 
 .. topic:: Examples:
 
@@ -281,7 +287,6 @@ of shape ``(n_samples, n_outputs)`` then the resulting estimator will:
   * Output a list of n_output arrays of class probabilities upon
     ``predict_proba``.
 
-
 The use of multi-output trees for regression is demonstrated in
 :ref:`sphx_glr_auto_examples_tree_plot_tree_regression_multioutput.py`. In this example, the input
 X is a single real value and the outputs Y are the sine and cosine of X.
@@ -303,15 +308,19 @@ the lower half of those faces.
 
 .. topic:: Examples:
 
- * :ref:`sphx_glr_auto_examples_tree_plot_tree_regression_multioutput.py`
- * :ref:`sphx_glr_auto_examples_miscellaneous_plot_multioutput_face_completion.py`
+  * :ref:`sphx_glr_auto_examples_tree_plot_tree_regression_multioutput.py`
+  * :ref:`sphx_glr_auto_examples_miscellaneous_plot_multioutput_face_completion.py`
 
-.. topic:: References:
+|details-start|
+**References**
+|details-split|
 
  * M. Dumont et al,  `Fast multi-class image annotation with random subwindows
    and multiple output randomized trees
    <http://www.montefiore.ulg.ac.be/services/stochastic/pubs/2009/DMWG09/dumont-visapp09-shortpaper.pdf>`_, International Conference on
    Computer Vision Theory and Applications 2009
+
+|details-end|
 
 .. _tree_complexity:
 
@@ -403,6 +412,10 @@ Tree algorithms: ID3, C4.5, C5.0 and CART
 What are all the various decision tree algorithms and how do they differ
 from each other? Which one is implemented in scikit-learn?
 
+|details-start|
+**Various decision tree algorithms**
+|details-split|
+
 ID3_ (Iterative Dichotomiser 3) was developed in 1986 by Ross Quinlan.
 The algorithm creates a multiway tree, finding for each node (i.e. in
 a greedy manner) the categorical feature that will yield the largest
@@ -427,6 +440,8 @@ CART (Classification and Regression Trees) is very similar to C4.5, but
 it differs in that it supports numerical target variables (regression) and
 does not compute rule sets. CART constructs binary trees using the feature
 and threshold that yield the largest information gain at each node.
+
+|details-end|
 
 scikit-learn uses an optimized version of the CART algorithm; however, the
 scikit-learn implementation does not support categorical variables for now.
@@ -500,8 +515,9 @@ Log Loss or Entropy:
 
     H(Q_m) = - \sum_k p_{mk} \log(p_{mk})
 
-
-.. note::
+|details-start|
+Shannon entropy:
+|details-split|
 
   The entropy criterion computes the Shannon entropy of the possible classes. It
   takes the class frequencies of the training data points that reached a given
@@ -530,6 +546,8 @@ Log Loss or Entropy:
   .. math::
 
       \mathrm{LL}(D, T) = \sum_{m \in T} \frac{n_m}{n} H(Q_m)
+
+|details-end|
 
 Regression criteria
 -------------------
@@ -671,7 +689,9 @@ be pruned. This process stops when the pruned tree's minimal
 
     * :ref:`sphx_glr_auto_examples_tree_plot_cost_complexity_pruning.py`
 
-.. topic:: References:
+|details-start|
+**References**
+|details-split|
 
     .. [BRE] L. Breiman, J. Friedman, R. Olshen, and C. Stone. Classification
       and Regression Trees. Wadsworth, Belmont, CA, 1984.
@@ -685,3 +705,5 @@ be pruned. This process stops when the pruned tree's minimal
 
     * T. Hastie, R. Tibshirani and J. Friedman. Elements of Statistical
       Learning, Springer, 2009.
+
+|details-end|

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1208,6 +1208,10 @@ div.install > input:checked + label {
   display: none;
 }
 
+pre.sk-expandable > span:before {
+  content: "$ ";
+}
+
 /* Show hidden content when the checkbox is checked */
 /* for conda */
 #quickstart-conda:checked  ~* [data-packager="conda"] {

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -18,6 +18,13 @@ Changes impacting all modules
 Changelog
 ---------
 
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| :class:`cluster.BisectingKMeans` could crash when predicting on data
+  with a different scale than the data used to fit the model.
+  :pr:`27167` by `Olivier Grisel`_.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/examples/cluster/plot_agglomerative_clustering.py
+++ b/examples/cluster/plot_agglomerative_clustering.py
@@ -7,7 +7,7 @@ local structure in the data. The graph is simply the graph of 20 nearest
 neighbors.
 
 There are two advantages of imposing a connectivity. First, clustering
-without a connectivity matrix is much faster.
+with sparse connectivity matrices is faster in general.
 
 Second, when using a connectivity matrix, single, average and complete
 linkage are unstable and tend to create a few clusters that grow very

--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -44,7 +44,8 @@ clf.fit(X_train, y_train)
 #
 # The decision classifier has an attribute called ``tree_`` which allows access
 # to low level attributes such as ``node_count``, the total number of nodes,
-# and ``max_depth``, the maximal depth of the tree. It also stores the
+# and ``max_depth``, the maximal depth of the tree. The tree_.compute_node_depths()
+# method computes the depth of each node in the tree. `tree_` also stores the
 # entire binary tree structure, represented as a number of parallel arrays. The
 # i-th element of each array holds information about the node ``i``. Node 0 is
 # the tree's root. Some of the arrays only apply to either leaves or split
@@ -63,6 +64,10 @@ clf.fit(X_train, y_train)
 #   - ``n_node_samples[i]``: the number of training samples reaching node
 #     ``i``
 #   - ``impurity[i]``: the impurity at node ``i``
+#   - ``weighted_n_node_samples[i]``: the weighted number of training samples
+#     reaching node ``i``
+#   - ``value[i, j, k]``: the summary of the training samples that reached node i for
+#     class j and output k.
 #
 # Using the arrays, we can traverse the tree structure to compute various
 # properties. Below, we will compute the depth of each node and whether or not
@@ -73,6 +78,7 @@ children_left = clf.tree_.children_left
 children_right = clf.tree_.children_right
 feature = clf.tree_.feature
 threshold = clf.tree_.threshold
+values = clf.tree_.value
 
 node_depth = np.zeros(shape=n_nodes, dtype=np.int64)
 is_leaves = np.zeros(shape=n_nodes, dtype=bool)
@@ -100,13 +106,13 @@ print(
 for i in range(n_nodes):
     if is_leaves[i]:
         print(
-            "{space}node={node} is a leaf node.".format(
-                space=node_depth[i] * "\t", node=i
+            "{space}node={node} is a leaf node with value={value}.".format(
+                space=node_depth[i] * "\t", node=i, value=values[i]
             )
         )
     else:
         print(
-            "{space}node={node} is a split node: "
+            "{space}node={node} is a split node with value={value}: "
             "go to node {left} if X[:, {feature}] <= {threshold} "
             "else to node {right}.".format(
                 space=node_depth[i] * "\t",
@@ -115,8 +121,29 @@ for i in range(n_nodes):
                 feature=feature[i],
                 threshold=threshold[i],
                 right=children_right[i],
+                value=values[i],
             )
         )
+
+# %%
+# What is the values array used here?
+# -----------------------------------
+# The `tree_.value` array is a 3D array of shape
+# [``n_nodes``, ``n_classes``, ``n_outputs``] which provides the count of samples
+# reaching a node for each class and for each output. Each node has a ``value``
+# array which is the number of weighted samples reaching this
+# node for each output and class.
+#
+# For example, in the above tree built on the iris dataset, the root node has
+# ``value = [37, 34, 41]``, indicating there are 37 samples
+# of class 0, 34 samples of class 1, and 41 samples of class 2 at the root node.
+# Traversing the tree, the samples are split and as a result, the ``value`` array
+# reaching each node changes. The left child of the root node has ``value = [37, 0, 0]``
+# because all 37 samples in the left child node are from class 0.
+#
+# Note: In this example, `n_outputs=1`, but the tree classifier can also handle
+# multi-output problems. The `value` array at each node would just be a 2D
+# array instead.
 
 ##############################################################################
 # We can compare the above output to the plot of the decision tree.

--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -90,7 +90,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_mutual_reachability(
     mst = np.empty(n_samples - 1, dtype=MST_edge_dtype)
     current_labels = np.arange(n_samples, dtype=np.int64)
     current_node = 0
-    min_reachability = np.full(n_samples, fill_value=np.infty, dtype=np.float64)
+    min_reachability = np.full(n_samples, fill_value=np.inf, dtype=np.float64)
     for i in range(0, n_samples - 1):
         label_filter = current_labels != current_node
         current_labels = current_labels[label_filter]
@@ -156,7 +156,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_data_matrix(
     mst = np.empty(n_samples - 1, dtype=MST_edge_dtype)
 
     in_tree = np.zeros(n_samples, dtype=np.uint8)
-    min_reachability = np.full(n_samples, fill_value=np.infty, dtype=np.float64)
+    min_reachability = np.full(n_samples, fill_value=np.inf, dtype=np.float64)
     current_sources = np.ones(n_samples, dtype=np.int64)
 
     current_node = 0

--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -4,10 +4,6 @@
 #
 # License: BSD 3 clause
 
-# TODO: We still need to use ndarrays instead of typed memoryviews when using
-# fused types and when the array may be read-only (for instance when it's
-# provided by the user). This is fixed in cython > 0.3.
-
 import numpy as np
 from cython cimport floating
 from cython.parallel cimport prange

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -259,6 +259,14 @@ def elkan_iter_chunked_dense(
         int n_features = X.shape[1]
         int n_clusters = centers_new.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do nothing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         # hard-coded number of samples per chunk. Splitting in chunks is
         # necessary to get parallelism. Chunk size chosen to be same as lloyd's
         int n_samples_chunk = CHUNK_SIZE if n_samples > CHUNK_SIZE else n_samples
@@ -494,6 +502,14 @@ def elkan_iter_chunked_sparse(
         int n_features = X.shape[1]
         int n_clusters = centers_new.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do nothing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         floating[::1] X_data = X.data
         int[::1] X_indices = X.indices
         int[::1] X_indptr = X.indptr

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -2,10 +2,6 @@
 #
 # Licence: BSD 3 clause
 
-# TODO: We still need to use ndarrays instead of typed memoryviews when using
-# fused types and when the array may be read-only (for instance when it's
-# provided by the user). This is fixed in cython > 0.3.
-
 from cython cimport floating
 from cython.parallel import prange, parallel
 from libc.stdlib cimport calloc, free

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -1,9 +1,5 @@
 # Licence: BSD 3 clause
 
-# TODO: We still need to use ndarrays instead of typed memoryviews when using
-# fused types and when the array may be read-only (for instance when it's
-# provided by the user). This is fixed in cython > 0.3.
-
 from cython cimport floating
 from cython.parallel import prange, parallel
 from libc.stdlib cimport malloc, calloc, free

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -78,6 +78,14 @@ def lloyd_iter_chunked_dense(
         int n_features = X.shape[1]
         int n_clusters = centers_old.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do nothing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         # hard-coded number of samples per chunk. Appeared to be close to
         # optimal in all situations.
         int n_samples_chunk = CHUNK_SIZE if n_samples > CHUNK_SIZE else n_samples
@@ -263,12 +271,19 @@ def lloyd_iter_chunked_sparse(
           the algorithm. This is useful especially when calling predict on a
           fitted model.
     """
-    # print(X.indices.dtype)
     cdef:
         int n_samples = X.shape[0]
         int n_features = X.shape[1]
         int n_clusters = centers_old.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do nothing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         # Choose same as for dense. Does not have the same impact since with
         # sparse data the pairwise distances matrix is not precomputed.
         # However, splitting in chunks is necessary to get parallelism.

--- a/sklearn/cluster/_k_means_minibatch.pyx
+++ b/sklearn/cluster/_k_means_minibatch.pyx
@@ -1,7 +1,3 @@
-# TODO: We still need to use ndarrays instead of typed memoryviews when using
-# fused types and when the array may be read-only (for instance when it's
-# provided by the user). This will be fixed in cython >= 0.3.
-
 from cython cimport floating
 from cython.parallel cimport parallel, prange
 from libc.stdlib cimport malloc, free

--- a/sklearn/cluster/tests/test_bisect_k_means.py
+++ b/sklearn/cluster/tests/test_bisect_k_means.py
@@ -133,3 +133,18 @@ def test_float32_float64_equivalence(csr_container):
 
     assert_allclose(km32.cluster_centers_, km64.cluster_centers_)
     assert_array_equal(km32.labels_, km64.labels_)
+
+
+@pytest.mark.parametrize("algorithm", ("lloyd", "elkan"))
+def test_no_crash_on_empty_bisections(algorithm):
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/27081
+    rng = np.random.RandomState(0)
+    X_train = rng.rand(3000, 10)
+    bkm = BisectingKMeans(n_clusters=10, algorithm=algorithm).fit(X_train)
+
+    # predict on scaled data to trigger pathologic case
+    # where the inner mask leads to empty bisections.
+    X_test = 50 * rng.rand(100, 10)
+    labels = bkm.predict(X_test)  # should not crash with idiv by 0
+    assert np.isin(np.unique(labels), np.arange(10)).all()

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -12,7 +12,6 @@ from tempfile import mkdtemp
 
 import numpy as np
 import pytest
-from scipy import sparse
 from scipy.cluster import hierarchy
 from scipy.sparse.csgraph import connected_components
 
@@ -48,6 +47,7 @@ from sklearn.utils._testing import (
     create_memmap_backed_data,
     ignore_warnings,
 )
+from sklearn.utils.fixes import LIL_CONTAINERS
 
 
 def test_linkage_misc():
@@ -176,7 +176,8 @@ def test_agglomerative_clustering_distances(
         assert not hasattr(clustering, "distances_")
 
 
-def test_agglomerative_clustering(global_random_seed):
+@pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+def test_agglomerative_clustering(global_random_seed, lil_container):
     # Check that we obtain the correct number of clusters with
     # agglomerative clustering.
     rng = np.random.RandomState(global_random_seed)
@@ -218,7 +219,7 @@ def test_agglomerative_clustering(global_random_seed):
         # Check that we raise a TypeError on dense matrices
         clustering = AgglomerativeClustering(
             n_clusters=10,
-            connectivity=sparse.lil_matrix(connectivity.toarray()[:10, :10]),
+            connectivity=lil_container(connectivity.toarray()[:10, :10]),
             linkage=linkage,
         )
         with pytest.raises(ValueError):

--- a/sklearn/datasets/descr/breast_cancer.rst
+++ b/sklearn/datasets/descr/breast_cancer.rst
@@ -104,15 +104,19 @@ This database is also available through the UW CS ftp server:
 ftp ftp.cs.wisc.edu
 cd math-prog/cpo-dataset/machine-learn/WDBC/
 
-.. topic:: References
+|details-start|
+**References**
+|details-split|
 
-   - W.N. Street, W.H. Wolberg and O.L. Mangasarian. Nuclear feature extraction 
-     for breast tumor diagnosis. IS&T/SPIE 1993 International Symposium on 
-     Electronic Imaging: Science and Technology, volume 1905, pages 861-870,
-     San Jose, CA, 1993.
-   - O.L. Mangasarian, W.N. Street and W.H. Wolberg. Breast cancer diagnosis and 
-     prognosis via linear programming. Operations Research, 43(4), pages 570-577, 
-     July-August 1995.
-   - W.H. Wolberg, W.N. Street, and O.L. Mangasarian. Machine learning techniques
-     to diagnose breast cancer from fine-needle aspirates. Cancer Letters 77 (1994) 
-     163-171.
+- W.N. Street, W.H. Wolberg and O.L. Mangasarian. Nuclear feature extraction 
+  for breast tumor diagnosis. IS&T/SPIE 1993 International Symposium on 
+  Electronic Imaging: Science and Technology, volume 1905, pages 861-870,
+  San Jose, CA, 1993.
+- O.L. Mangasarian, W.N. Street and W.H. Wolberg. Breast cancer diagnosis and 
+  prognosis via linear programming. Operations Research, 43(4), pages 570-577, 
+  July-August 1995.
+- W.H. Wolberg, W.N. Street, and O.L. Mangasarian. Machine learning techniques
+  to diagnose breast cancer from fine-needle aspirates. Cancer Letters 77 (1994) 
+  163-171.
+
+|details-end|

--- a/sklearn/datasets/descr/digits.rst
+++ b/sklearn/datasets/descr/digits.rst
@@ -32,15 +32,19 @@ T. Candela, D. L. Dimmick, J. Geist, P. J. Grother, S. A. Janet, and C.
 L. Wilson, NIST Form-Based Handprint Recognition System, NISTIR 5469,
 1994.
 
-.. topic:: References
+|details-start|
+**References**
+|details-split|
 
-  - C. Kaynak (1995) Methods of Combining Multiple Classifiers and Their
-    Applications to Handwritten Digit Recognition, MSc Thesis, Institute of
-    Graduate Studies in Science and Engineering, Bogazici University.
-  - E. Alpaydin, C. Kaynak (1998) Cascading Classifiers, Kybernetika.
-  - Ken Tang and Ponnuthurai N. Suganthan and Xi Yao and A. Kai Qin.
-    Linear dimensionalityreduction using relevance weighted LDA. School of
-    Electrical and Electronic Engineering Nanyang Technological University.
-    2005.
-  - Claudio Gentile. A New Approximate Maximal Margin Classification
-    Algorithm. NIPS. 2000.
+- C. Kaynak (1995) Methods of Combining Multiple Classifiers and Their
+  Applications to Handwritten Digit Recognition, MSc Thesis, Institute of
+  Graduate Studies in Science and Engineering, Bogazici University.
+- E. Alpaydin, C. Kaynak (1998) Cascading Classifiers, Kybernetika.
+- Ken Tang and Ponnuthurai N. Suganthan and Xi Yao and A. Kai Qin.
+  Linear dimensionalityreduction using relevance weighted LDA. School of
+  Electrical and Electronic Engineering Nanyang Technological University.
+  2005.
+- Claudio Gentile. A New Approximate Maximal Margin Classification
+  Algorithm. NIPS. 2000.
+
+|details-end|

--- a/sklearn/datasets/descr/iris.rst
+++ b/sklearn/datasets/descr/iris.rst
@@ -45,19 +45,23 @@ data set contains 3 classes of 50 instances each, where each class refers to a
 type of iris plant.  One class is linearly separable from the other 2; the
 latter are NOT linearly separable from each other.
 
-.. topic:: References
+|details-start|
+**References**
+|details-split|
 
-   - Fisher, R.A. "The use of multiple measurements in taxonomic problems"
-     Annual Eugenics, 7, Part II, 179-188 (1936); also in "Contributions to
-     Mathematical Statistics" (John Wiley, NY, 1950).
-   - Duda, R.O., & Hart, P.E. (1973) Pattern Classification and Scene Analysis.
-     (Q327.D83) John Wiley & Sons.  ISBN 0-471-22361-1.  See page 218.
-   - Dasarathy, B.V. (1980) "Nosing Around the Neighborhood: A New System
-     Structure and Classification Rule for Recognition in Partially Exposed
-     Environments".  IEEE Transactions on Pattern Analysis and Machine
-     Intelligence, Vol. PAMI-2, No. 1, 67-71.
-   - Gates, G.W. (1972) "The Reduced Nearest Neighbor Rule".  IEEE Transactions
-     on Information Theory, May 1972, 431-433.
-   - See also: 1988 MLC Proceedings, 54-64.  Cheeseman et al"s AUTOCLASS II
-     conceptual clustering system finds 3 classes in the data.
-   - Many, many more ...
+- Fisher, R.A. "The use of multiple measurements in taxonomic problems"
+  Annual Eugenics, 7, Part II, 179-188 (1936); also in "Contributions to
+  Mathematical Statistics" (John Wiley, NY, 1950).
+- Duda, R.O., & Hart, P.E. (1973) Pattern Classification and Scene Analysis.
+  (Q327.D83) John Wiley & Sons.  ISBN 0-471-22361-1.  See page 218.
+- Dasarathy, B.V. (1980) "Nosing Around the Neighborhood: A New System
+  Structure and Classification Rule for Recognition in Partially Exposed
+  Environments".  IEEE Transactions on Pattern Analysis and Machine
+  Intelligence, Vol. PAMI-2, No. 1, 67-71.
+- Gates, G.W. (1972) "The Reduced Nearest Neighbor Rule".  IEEE Transactions
+  on Information Theory, May 1972, 431-433.
+- See also: 1988 MLC Proceedings, 54-64.  Cheeseman et al"s AUTOCLASS II
+  conceptual clustering system finds 3 classes in the data.
+- Many, many more ...
+
+|details-end|

--- a/sklearn/datasets/descr/linnerud.rst
+++ b/sklearn/datasets/descr/linnerud.rst
@@ -18,7 +18,11 @@ twenty middle-aged men in a fitness club:
 - *exercise* - CSV containing 20 observations on 3 exercise variables:
    Chins, Situps and Jumps.
 
-.. topic:: References
+|details-start|
+**References**
+|details-split|
 
-  * Tenenhaus, M. (1998). La regression PLS: theorie et pratique. Paris:
-    Editions Technic.
+* Tenenhaus, M. (1998). La regression PLS: theorie et pratique. Paris:
+  Editions Technic.
+
+|details-end|

--- a/sklearn/datasets/descr/wine_data.rst
+++ b/sklearn/datasets/descr/wine_data.rst
@@ -74,22 +74,26 @@ Lichman, M. (2013). UCI Machine Learning Repository
 [https://archive.ics.uci.edu/ml]. Irvine, CA: University of California,
 School of Information and Computer Science. 
 
-.. topic:: References
+|details-start|
+**References**
+|details-split|
 
-  (1) S. Aeberhard, D. Coomans and O. de Vel, 
-  Comparison of Classifiers in High Dimensional Settings, 
-  Tech. Rep. no. 92-02, (1992), Dept. of Computer Science and Dept. of  
-  Mathematics and Statistics, James Cook University of North Queensland. 
-  (Also submitted to Technometrics). 
+(1) S. Aeberhard, D. Coomans and O. de Vel, 
+Comparison of Classifiers in High Dimensional Settings, 
+Tech. Rep. no. 92-02, (1992), Dept. of Computer Science and Dept. of  
+Mathematics and Statistics, James Cook University of North Queensland. 
+(Also submitted to Technometrics). 
 
-  The data was used with many others for comparing various 
-  classifiers. The classes are separable, though only RDA 
-  has achieved 100% correct classification. 
-  (RDA : 100%, QDA 99.4%, LDA 98.9%, 1NN 96.1% (z-transformed data)) 
-  (All results using the leave-one-out technique) 
+The data was used with many others for comparing various 
+classifiers. The classes are separable, though only RDA 
+has achieved 100% correct classification. 
+(RDA : 100%, QDA 99.4%, LDA 98.9%, 1NN 96.1% (z-transformed data)) 
+(All results using the leave-one-out technique) 
 
-  (2) S. Aeberhard, D. Coomans and O. de Vel, 
-  "THE CLASSIFICATION PERFORMANCE OF RDA" 
-  Tech. Rep. no. 92-01, (1992), Dept. of Computer Science and Dept. of 
-  Mathematics and Statistics, James Cook University of North Queensland. 
-  (Also submitted to Journal of Chemometrics).
+(2) S. Aeberhard, D. Coomans and O. de Vel, 
+"THE CLASSIFICATION PERFORMANCE OF RDA" 
+Tech. Rep. no. 92-01, (1992), Dept. of Computer Science and Dept. of 
+Mathematics and Statistics, James Cook University of North Queensland. 
+(Also submitted to Journal of Chemometrics).
+
+|details-end|

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -192,9 +192,9 @@ def test_imputation_adds_missing_indicator_if_add_indicator_is_true(
 
     Non-regression test for gh-26590.
     """
-    X_train = np.array([[0, np.NaN], [1, 2]])
+    X_train = np.array([[0, np.nan], [1, 2]])
 
-    # Test data where missing_value_test variable can be set to np.NaN or 1.
+    # Test data where missing_value_test variable can be set to np.nan or 1.
     X_test = np.array([[0, missing_value_test], [1, 2]])
 
     imputer.set_params(add_indicator=True)

--- a/sklearn/neighbors/_ball_tree.pyx.tp
+++ b/sklearn/neighbors/_ball_tree.pyx.tp
@@ -96,14 +96,14 @@ cdef int init_node{{name_suffix}}(
 
     cdef intp_t i, j
     cdef float64_t radius
-    cdef {{INPUT_DTYPE_t}} *this_pt
+    cdef const {{INPUT_DTYPE_t}} *this_pt
 
     cdef intp_t* idx_array = &tree.idx_array[0]
-    cdef {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
+    cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
     cdef {{INPUT_DTYPE_t}}* centroid = &tree.node_bounds[0, i_node, 0]
 
     cdef bint with_sample_weight = tree.sample_weight is not None
-    cdef {{INPUT_DTYPE_t}}* sample_weight
+    cdef const {{INPUT_DTYPE_t}}* sample_weight
     cdef float64_t sum_weight_node
     if with_sample_weight:
         sample_weight = &tree.sample_weight[0]
@@ -148,7 +148,7 @@ cdef int init_node{{name_suffix}}(
 cdef inline float64_t min_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum distance between a point and a node"""
     cdef float64_t dist_pt = tree.dist(pt, &tree.node_bounds[0, i_node, 0],
@@ -159,7 +159,7 @@ cdef inline float64_t min_dist{{name_suffix}}(
 cdef inline float64_t max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum distance between a point and a node"""
     cdef float64_t dist_pt = tree.dist(pt, &tree.node_bounds[0, i_node, 0],
@@ -170,7 +170,7 @@ cdef inline float64_t max_dist{{name_suffix}}(
 cdef inline int min_max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
     float64_t* min_dist,
     float64_t* max_dist,
 ) except -1 nogil:
@@ -186,7 +186,7 @@ cdef inline int min_max_dist{{name_suffix}}(
 cdef inline float64_t min_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum reduced-distance between a point and a node"""
     if tree.euclidean:
@@ -202,7 +202,7 @@ cdef inline float64_t min_rdist{{name_suffix}}(
 cdef inline float64_t max_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum reduced-distance between a point and a node"""
     if tree.euclidean:

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -602,7 +602,7 @@ cdef class NeighborsHeap{{name_suffix}}:
 #  this computes the equivalent of
 #  j_max = np.argmax(np.max(data, 0) - np.min(data, 0))
 cdef intp_t find_node_split_dim(const floating* data,
-                                 intp_t* node_indices,
+                                 const intp_t* node_indices,
                                  intp_t n_features,
                                  intp_t n_points) except -1:
     """Find the dimension with the largest spread.
@@ -806,6 +806,9 @@ cdef class BinaryTree{{name_suffix}}:
     cdef readonly const {{INPUT_DTYPE_t}}[::1] sample_weight
     cdef public float64_t sum_weight
 
+    # TODO: idx_array and node_bounds must not be const, but this change needs
+    # to happen in a way which preserves pickling
+    # See also: https://github.com/cython/cython/issues/5639
     cdef public const intp_t[::1] idx_array
     cdef public const NodeData_t[::1] node_data
     cdef public const {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
@@ -1010,7 +1013,7 @@ cdef class BinaryTree{{name_suffix}}:
             self.node_bounds.base,
         )
 
-    cdef inline float64_t dist(self, {{INPUT_DTYPE_t}}* x1, {{INPUT_DTYPE_t}}* x2,
+    cdef inline float64_t dist(self, const {{INPUT_DTYPE_t}}* x1, const {{INPUT_DTYPE_t}}* x2,
                              intp_t size) except -1 nogil:
         """Compute the distance between arrays x1 and x2"""
         self.n_calls += 1
@@ -1019,7 +1022,7 @@ cdef class BinaryTree{{name_suffix}}:
         else:
             return self.dist_metric.dist(x1, x2, size)
 
-    cdef inline float64_t rdist(self, {{INPUT_DTYPE_t}}* x1, {{INPUT_DTYPE_t}}* x2,
+    cdef inline float64_t rdist(self, const {{INPUT_DTYPE_t}}* x1, const {{INPUT_DTYPE_t}}* x2,
                               intp_t size) except -1 nogil:
         """Compute the reduced distance between arrays x1 and x2.
 
@@ -1051,7 +1054,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t n_points = idx_end - idx_start
         cdef intp_t n_mid = n_points / 2
         cdef intp_t* idx_array = &self.idx_array[idx_start]
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # initialize node data
         init_node{{name_suffix}}(self, node_data, i_node, idx_start, idx_end)
@@ -1146,7 +1149,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef const {{INPUT_DTYPE_t}}[:, ::1] Xarr = np_Xarr
         cdef float64_t reduced_dist_LB
         cdef intp_t i
-        cdef {{INPUT_DTYPE_t}}* pt
+        cdef const {{INPUT_DTYPE_t}}* pt
 
         # initialize heap for neighbors
         cdef NeighborsHeap{{name_suffix}} heap = NeighborsHeap{{name_suffix}}(Xarr.shape[0], k)
@@ -1263,7 +1266,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t n_features = self.data.shape[1]
         cdef {{INPUT_DTYPE_t}}[::1] dist_arr_i
         cdef intp_t[::1] idx_arr_i, counts
-        cdef {{INPUT_DTYPE_t}}* pt
+        cdef const {{INPUT_DTYPE_t}}* pt
         cdef intp_t** indices = NULL
         cdef {{INPUT_DTYPE_t}}** distances = NULL
 
@@ -1484,7 +1487,7 @@ cdef class BinaryTree{{name_suffix}}:
         log_density_arr = np.zeros(Xarr.shape[0], dtype={{INPUT_DTYPE}})
         cdef {{INPUT_DTYPE_t}}[::1] log_density = log_density_arr
 
-        cdef {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
 
         cdef NodeHeap nodeheap
         if breadth_first:
@@ -1589,7 +1592,7 @@ cdef class BinaryTree{{name_suffix}}:
         count = np.zeros(r.shape[0], dtype=np.intp)
         cdef intp_t[::1] carr = count
 
-        cdef {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
 
         if dualtree:
             other = self.__class__(Xarr, metric=self.dist_metric,
@@ -1607,7 +1610,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _query_single_depthfirst(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         intp_t i_pt,
         NeighborsHeap{{name_suffix}} heap,
         float64_t reduced_dist_LB,
@@ -1618,7 +1621,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef float64_t dist_pt, reduced_dist_LB_1, reduced_dist_LB_2
         cdef intp_t i, i1, i2
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # ------------------------------------------------------------
         # Case 1: query point is outside node radius:
@@ -1661,7 +1664,7 @@ cdef class BinaryTree{{name_suffix}}:
 
     cdef int _query_single_breadthfirst(
         self,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         intp_t i_pt,
         NeighborsHeap{{name_suffix}} heap,
         NodeHeap nodeheap,
@@ -1669,8 +1672,8 @@ cdef class BinaryTree{{name_suffix}}:
         """Non-recursive single-tree k-neighbors query, breadth-first search"""
         cdef intp_t i, i_node
         cdef float64_t dist_pt, reduced_dist_LB
-        cdef NodeData_t* node_data = &self.node_data[0]
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # Set up the node heap and push the head node onto it
         cdef NodeHeapData_t nodeheap_item
@@ -1727,8 +1730,8 @@ cdef class BinaryTree{{name_suffix}}:
         cdef NodeData_t node_info1 = self.node_data[i_node1]
         cdef NodeData_t node_info2 = other.node_data[i_node2]
 
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t n_features = self.data.shape[1]
 
         cdef float64_t bound_max, dist_pt, reduced_dist_LB1, reduced_dist_LB2
@@ -1826,11 +1829,11 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t i, i1, i2, i_node1, i_node2, i_pt
         cdef float64_t dist_pt, reduced_dist_LB
         cdef float64_t[::1] bounds = np.full(other.node_data.shape[0], np.inf)
-        cdef NodeData_t* node_data1 = &self.node_data[0]
-        cdef NodeData_t* node_data2 = &other.node_data[0]
+        cdef const NodeData_t* node_data1 = &self.node_data[0]
+        cdef const NodeData_t* node_data2 = &other.node_data[0]
         cdef NodeData_t node_info1, node_info2
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t n_features = self.data.shape[1]
 
         # Set up the node heap and push the head nodes onto it
@@ -1906,7 +1909,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef intp_t _query_radius_single(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         float64_t r,
         intp_t* indices,
         {{INPUT_DTYPE_t}}* distances,
@@ -1915,7 +1918,7 @@ cdef class BinaryTree{{name_suffix}}:
         int return_distance,
     ) noexcept nogil:
         """recursive single-tree radius query, depth-first"""
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef intp_t* idx_array = &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
@@ -1983,7 +1986,7 @@ cdef class BinaryTree{{name_suffix}}:
         return count
 
     cdef float64_t _kde_single_breadthfirst(
-        self, {{INPUT_DTYPE_t}}* pt,
+        self, const {{INPUT_DTYPE_t}}* pt,
         KernelType kernel,
         float64_t h,
         float64_t log_knorm,
@@ -2006,13 +2009,13 @@ cdef class BinaryTree{{name_suffix}}:
         cdef float64_t global_log_min_bound, global_log_bound_spread
         cdef float64_t global_log_max_bound
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef bint with_sample_weight = self.sample_weight is not None
-        cdef {{INPUT_DTYPE_t}}* sample_weight
+        cdef const {{INPUT_DTYPE_t}}* sample_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
         cdef intp_t* idx_array = &self.idx_array[0]
-        cdef NodeData_t* node_data = &self.node_data[0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
         cdef float64_t N
         cdef float64_t log_weight
         if with_sample_weight:
@@ -2153,7 +2156,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _kde_single_depthfirst(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         KernelType kernel,
         float64_t h,
         float64_t log_knorm,
@@ -2173,10 +2176,10 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t i, i1, i2, iw, start, end
         cdef float64_t N1, N2
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
-        cdef NodeData_t* node_data = &self.node_data[0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
         cdef bint with_sample_weight = self.sample_weight is not None
-        cdef {{INPUT_DTYPE_t}}* sample_weight
+        cdef const {{INPUT_DTYPE_t}}* sample_weight
         cdef float64_t log_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
@@ -2295,14 +2298,14 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _two_point_single(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         float64_t* r,
         intp_t* count,
         intp_t i_min,
         intp_t i_max,
     ) except -1:
         """recursive single-tree two-point correlation function query"""
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef intp_t* idx_array = &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
@@ -2358,8 +2361,8 @@ cdef class BinaryTree{{name_suffix}}:
         intp_t i_max,
     ) except -1:
         """recursive dual-tree two-point correlation function query"""
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t* idx_array1 = &self.idx_array[0]
         cdef intp_t* idx_array2 = &other.idx_array[0]
         cdef NodeData_t node_info1 = self.node_data[i_node1]
@@ -2469,9 +2472,9 @@ def nodeheap_sort(float64_t[::1] vals):
 
 
 cdef inline float64_t _total_node_weight(
-    NodeData_t* node_data,
+    const NodeData_t* node_data,
     const floating* sample_weight,
-    intp_t* idx_array,
+    const intp_t* idx_array,
     intp_t i_node,
 ):
     cdef intp_t i

--- a/sklearn/neighbors/_kd_tree.pyx.tp
+++ b/sklearn/neighbors/_kd_tree.pyx.tp
@@ -84,10 +84,10 @@ cdef int init_node{{name_suffix}}(
 
     cdef {{INPUT_DTYPE_t}}* lower_bounds = &tree.node_bounds[0, i_node, 0]
     cdef {{INPUT_DTYPE_t}}* upper_bounds = &tree.node_bounds[1, i_node, 0]
-    cdef {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
-    cdef intp_t* idx_array = &tree.idx_array[0]
+    cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
+    cdef const intp_t* idx_array = &tree.idx_array[0]
 
-    cdef {{INPUT_DTYPE_t}}* data_row
+    cdef const {{INPUT_DTYPE_t}}* data_row
 
     # determine Node bounds
     for j in range(n_features):
@@ -123,7 +123,7 @@ cdef int init_node{{name_suffix}}(
 cdef float64_t min_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum reduced-distance between a point and a node"""
     cdef intp_t n_features = tree.data.shape[1]
@@ -150,7 +150,7 @@ cdef float64_t min_rdist{{name_suffix}}(
 cdef float64_t min_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the minimum distance between a point and a node"""
     if tree.dist_metric.p == INF:
@@ -165,7 +165,7 @@ cdef float64_t min_dist{{name_suffix}}(
 cdef float64_t max_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum reduced-distance between a point and a node"""
     cdef intp_t n_features = tree.data.shape[1]
@@ -189,7 +189,7 @@ cdef float64_t max_rdist{{name_suffix}}(
 cdef float64_t max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum distance between a point and a node"""
     if tree.dist_metric.p == INF:
@@ -204,7 +204,7 @@ cdef float64_t max_dist{{name_suffix}}(
 cdef inline int min_max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
     float64_t* min_dist,
     float64_t* max_dist,
 ) except -1 nogil:

--- a/sklearn/neighbors/_partition_nodes.pxd
+++ b/sklearn/neighbors/_partition_nodes.pxd
@@ -2,7 +2,7 @@ from cython cimport floating
 from ..utils._typedefs cimport float64_t, intp_t
 
 cdef int partition_node_indices(
-        floating *data,
+        const floating *data,
         intp_t *node_indices,
         intp_t split_dim,
         intp_t split_index,

--- a/sklearn/neighbors/_partition_nodes.pyx
+++ b/sklearn/neighbors/_partition_nodes.pyx
@@ -56,7 +56,7 @@ cdef extern from *:
     }
     """
     void partition_node_indices_inner[D, I](
-                D *data,
+                const D *data,
                 I *node_indices,
                 I split_dim,
                 I split_index,
@@ -65,7 +65,7 @@ cdef extern from *:
 
 
 cdef int partition_node_indices(
-        floating *data,
+        const floating *data,
         intp_t *node_indices,
         intp_t split_dim,
         intp_t split_index,

--- a/sklearn/neighbors/tests/test_lof.py
+++ b/sklearn/neighbors/tests/test_lof.py
@@ -7,7 +7,6 @@ from math import sqrt
 
 import numpy as np
 import pytest
-from scipy.sparse import csr_matrix
 
 from sklearn import metrics, neighbors
 from sklearn.datasets import load_iris
@@ -18,6 +17,7 @@ from sklearn.utils.estimator_checks import (
     check_outlier_corruption,
     parametrize_with_checks,
 )
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 # load the iris dataset
 # and randomly permute it
@@ -238,11 +238,12 @@ def test_predicted_outlier_number(expected_outliers):
         check_outlier_corruption(num_outliers, expected_outliers, y_dec)
 
 
-def test_sparse():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_sparse(csr_container):
     # LocalOutlierFactor must support CSR inputs
     # TODO: compare results on dense and sparse data as proposed in:
     # https://github.com/scikit-learn/scikit-learn/pull/23585#discussion_r968388186
-    X = csr_matrix(iris.data)
+    X = csr_container(iris.data)
 
     lof = neighbors.LocalOutlierFactor(novelty=True)
     lof.fit(X)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -18,7 +18,6 @@ from numpy.testing import (
     assert_almost_equal,
     assert_array_equal,
 )
-from scipy.sparse import csr_matrix
 
 from sklearn.datasets import (
     load_digits,
@@ -31,6 +30,7 @@ from sklearn.metrics import roc_auc_score
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 from sklearn.preprocessing import LabelBinarizer, MinMaxScaler, scale
 from sklearn.utils._testing import ignore_warnings
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 ACTIVATION_TYPES = ["identity", "logistic", "tanh", "relu"]
 
@@ -626,11 +626,12 @@ def test_shuffle():
     assert not np.array_equal(mlp1.coefs_[0], mlp2.coefs_[0])
 
 
-def test_sparse_matrices():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_sparse_matrices(csr_container):
     # Test that sparse and dense input matrices output the same results.
     X = X_digits_binary[:50]
     y = y_digits_binary[:50]
-    X_sparse = csr_matrix(X)
+    X_sparse = csr_container(X)
     mlp = MLPClassifier(solver="lbfgs", hidden_layer_sizes=15, random_state=1)
     mlp.fit(X, y)
     pred1 = mlp.predict(X)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -414,7 +414,7 @@ def test_X_is_not_1D_pandas(method):
             np.object_,
         ),
         (np.array([["A", "cat"], ["B", "cat"]]), [["A", "B"], ["cat"]], np.str_),
-        (np.array([[1, 2], [np.nan, 2]]), [[1, np.nan], [2]], np.float_),
+        (np.array([[1, 2], [np.nan, 2]]), [[1, np.nan], [2]], np.float64),
         (
             np.array([["A", np.nan], [None, np.nan]], dtype=object),
             [["A", None], [np.nan]],

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -714,6 +714,9 @@ cdef class Tree:
         children_right[i] > i. This child handles the case where
         X[:, feature[i]] > threshold[i].
 
+    n_leaves : int
+        Number of leaves in the tree.
+
     feature : array of int, shape [node_count]
         feature[i] holds the feature to split on, for the internal node i.
 
@@ -733,6 +736,10 @@ cdef class Tree:
     weighted_n_node_samples : array of double, shape [node_count]
         weighted_n_node_samples[i] holds the weighted number of training samples
         reaching node i.
+
+    missing_go_to_left : array of bool, shape [node_count]
+        missing_go_to_left[i] holds a bool indicating whether or not there were
+        missing values at node i.
     """
     # Wrap for outside world.
     # WARNING: these reference the current `nodes` and `value` buffers, which

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -157,10 +157,11 @@ def compute_sample_weight(class_weight, y, *, indices=None):
 
     expanded_class_weight = []
     for k in range(n_outputs):
-        y_full = y[:, k]
-        if sparse.issparse(y_full):
+        if sparse.issparse(y):
             # Ok to densify a single column at a time
-            y_full = y_full.toarray().flatten()
+            y_full = y[:, [k]].toarray().flatten()
+        else:
+            y_full = y[:, k]
         classes_full = np.unique(y_full)
         classes_missing = None
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -197,6 +197,6 @@ def _contents(data_module):
 # For +1.25 NumPy versions exceptions and warnings are being moved
 # to a dedicated submodule.
 if np_version >= parse_version("1.25.0"):
-    from numpy.exceptions import VisibleDeprecationWarning
+    from numpy.exceptions import ComplexWarning, VisibleDeprecationWarning
 else:
-    from numpy import VisibleDeprecationWarning  # type: ignore  # noqa
+    from numpy import ComplexWarning, VisibleDeprecationWarning  # type: ignore  # noqa

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from scipy import sparse
 
 from sklearn.datasets import make_blobs
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._testing import assert_almost_equal, assert_array_almost_equal
 from sklearn.utils.class_weight import compute_class_weight, compute_sample_weight
+from sklearn.utils.fixes import CSC_CONTAINERS
 
 
 def test_compute_class_weight():
@@ -308,8 +308,9 @@ def test_class_weight_does_not_contains_more_classes():
     tree.fit([[0, 0, 1], [1, 0, 1], [1, 2, 0]], [0, 0, 1])
 
 
-def test_compute_sample_weight_sparse():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_compute_sample_weight_sparse(csc_container):
     """Check that we can compute weight for sparse `y`."""
-    y = sparse.csc_matrix(np.asarray([0, 1, 1])).T
+    y = csc_container(np.asarray([0, 1, 1])).T
     sample_weight = compute_sample_weight("balanced", y)
     assert_allclose(sample_weight, [1.5, 0.75, 0.75])

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1586,7 +1586,7 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
 @pytest.mark.parametrize(
     "ntype1, ntype2, expected_subtype",
     [
-        ("longfloat", "longdouble", np.floating),
+        ("double", "longdouble", np.floating),
         ("float16", "half", np.floating),
         ("single", "float32", np.floating),
         ("double", "float64", np.floating),

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -21,12 +21,10 @@ import joblib
 import numpy as np
 import scipy.sparse as sp
 
-# mypy error: Module 'numpy.core.numeric' has no attribute 'ComplexWarning'
-from numpy.core.numeric import ComplexWarning  # type: ignore
-
 from .. import get_config as _get_config
 from ..exceptions import DataConversionWarning, NotFittedError, PositiveSpectrumWarning
 from ..utils._array_api import _asarray_with_order, _is_numpy_namespace, get_namespace
+from ..utils.fixes import ComplexWarning
 from ._isfinite import FiniteStatus, cy_isfinite
 from .fixes import _object_dtype_isnan
 


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes #27159

**Explain Changes**:
This commit adds information about various methods used for decision tree splitting , including their use for regression and classification tasks . It also includes suggestions for what method should be chosen based on the 
task requirements. It makes user aware of the computational complexity of each method be it Variance Reduction , Gini Impurity or Chi-Square method and what should be used for better accuracy. It also includes suggestions like what method is suitable for larger and smaller datasets , hence helping users to choose wisely.
